### PR TITLE
Add better conversations javadoc

### DIFF
--- a/src/main/java/io/blamer/bot/agents/tg/TgBot.java
+++ b/src/main/java/io/blamer/bot/agents/tg/TgBot.java
@@ -61,7 +61,14 @@ public class TgBot extends TelegramLongPollingBot {
   private final ExtTg configuration;
 
   /**
-   * Conversations.
+   * Conversations is a bean map, the key is the bean id,
+   * the value is the Conversation bean implementation.
+   * All beans that implement the Conversation interface
+   * have a bean id equal to the text command it handles.
+   * <p>
+   * Spring automatically injects these fields,
+   * allowing us to avoid gigantic <i>if/else</i>
+   * or <i>switch/case</i> constructs.
    */
   private final Map<String, Conversation> conversations;
 


### PR DESCRIPTION
closes #24 

@h1alexbel take a look, please

this comment is clear enough, wdyt?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds documentation to the `TgBot` class about the use of the `conversations` field.

### Detailed summary
- Added documentation explaining that `conversations` is a bean map with keys as bean ids and values as the `Conversation` bean implementation.
- Explained that all beans implementing the `Conversation` interface have a bean id equal to the text command it handles.
- Mentioned that Spring automatically injects these fields to avoid large `if/else` or `switch/case` constructs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->