### PR TITLE
2 spaces indents over 4, response package's name fix

### DIFF
--- a/src/main/java/io/blamer/bot/conversation/Conversation.java
+++ b/src/main/java/io/blamer/bot/conversation/Conversation.java
@@ -53,16 +53,16 @@ import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
  */
 public interface Conversation {
 
-    /**
-     * Creates message to handle with specific command.
-     *
-     * @param update The update to handle
-     * @return SendMessage event
-     */
-    SendMessage messageFromUpdate(Update update);
+  /**
+   * Creates message to handle with specific command.
+   *
+   * @param update The update to handle
+   * @return SendMessage event
+   */
+  SendMessage messageFromUpdate(Update update);
 
-    /**
-     * @return Description of this command.
-     */
-    BotCommand asBotCommand();
+  /**
+   * @return Description of this command.
+   */
+  BotCommand asBotCommand();
 }

--- a/src/main/java/io/blamer/bot/conversation/routes/Registry.java
+++ b/src/main/java/io/blamer/bot/conversation/routes/Registry.java
@@ -25,7 +25,7 @@
 package io.blamer.bot.conversation.routes;
 
 import io.blamer.bot.conversation.Conversation;
-import io.blamer.bot.reponse.RegistryResponse;
+import io.blamer.bot.response.RegistryResponse;
 import io.blamer.bot.request.RegistryRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/io/blamer/bot/response/RegistryResponse.java
+++ b/src/main/java/io/blamer/bot/response/RegistryResponse.java
@@ -22,7 +22,29 @@
  * SOFTWARE.
  */
 
+package io.blamer.bot.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- * Responses package.
+ * Response with info about auth status.
  */
-package io.blamer.bot.reponse;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RegistryResponse {
+
+  /**
+   * Text for auth info message.
+   */
+  private String text;
+
+  /**
+   * Chat to send auth info.
+   */
+  private String chat;
+}

--- a/src/main/java/io/blamer/bot/response/package-info.java
+++ b/src/main/java/io/blamer/bot/response/package-info.java
@@ -22,29 +22,7 @@
  * SOFTWARE.
  */
 
-package io.blamer.bot.reponse;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
- * Response with info about auth status.
+ * Responses package.
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class RegistryResponse {
-
-  /**
-   * Text for auth info message.
-   */
-  private String text;
-
-  /**
-   * Chat to send auth info.
-   */
-  private String chat;
-}
+package io.blamer.bot.response;

--- a/src/test/java/io/blamer/bot/agents/tg/TgBotTest.java
+++ b/src/test/java/io/blamer/bot/agents/tg/TgBotTest.java
@@ -4,9 +4,11 @@ import annotation.TestWithSpringContext;
 import io.blamer.bot.conversation.Conversation;
 import io.blamer.bot.conversation.routes.Registry;
 import io.blamer.bot.conversation.routes.Start;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/blamer/bot/conversation/routes/RegistryTest.java
+++ b/src/test/java/io/blamer/bot/conversation/routes/RegistryTest.java
@@ -43,43 +43,43 @@ import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
 @ExtendWith(MockitoExtension.class)
 class RegistryTest {
 
-    @Autowired
-    private Registry messageGenerator;
+  @Autowired
+  private Registry messageGenerator;
 
-    @Test
-    void createsRegistryMessage(@Mock final Update update, @Mock final Message message) {
-        final String expected = "`Retries exhausted: 3/3`";
-        Mockito.when(message.getText()).thenReturn("/registry tkn");
-        Mockito.when(update.getMessage()).thenReturn(message);
-        Assertions.assertNotNull(this.messageGenerator.messageFromUpdate(update));
-        MatcherAssert.assertThat(
-          "Response contains right text",
-          this.messageGenerator.messageFromUpdate(update).getText(),
-          Matchers.equalTo(expected)
-        );
-    }
+  @Test
+  void createsRegistryMessage(@Mock final Update update, @Mock final Message message) {
+    final String expected = "`Retries exhausted: 3/3`";
+    Mockito.when(message.getText()).thenReturn("/registry tkn");
+    Mockito.when(update.getMessage()).thenReturn(message);
+    Assertions.assertNotNull(this.messageGenerator.messageFromUpdate(update));
+    MatcherAssert.assertThat(
+      "Response contains right text",
+      this.messageGenerator.messageFromUpdate(update).getText(),
+      Matchers.equalTo(expected)
+    );
+  }
 
-    @Test
-    void createsRegistryMessageWithError(@Mock final Update update, @Mock final Message message) {
-        final String expected = "`Retries exhausted: 3/3`";
-        Mockito.when(message.getText()).thenReturn("/registry");
-        Mockito.when(update.getMessage()).thenReturn(message);
-        final SendMessage actual = this.messageGenerator.messageFromUpdate(update);
-        Assertions.assertNotNull(actual);
-        MatcherAssert.assertThat(
-          "Response contains right text",
-            actual.getText(),
-            Matchers.equalTo(expected)
-        );
-    }
+  @Test
+  void createsRegistryMessageWithError(@Mock final Update update, @Mock final Message message) {
+    final String expected = "`Retries exhausted: 3/3`";
+    Mockito.when(message.getText()).thenReturn("/registry");
+    Mockito.when(update.getMessage()).thenReturn(message);
+    final SendMessage actual = this.messageGenerator.messageFromUpdate(update);
+    Assertions.assertNotNull(actual);
+    MatcherAssert.assertThat(
+      "Response contains right text",
+      actual.getText(),
+      Matchers.equalTo(expected)
+    );
+  }
 
-    @Test
-    void createsBotCommand() {
-        final BotCommand actual = this.messageGenerator.asBotCommand();
-        MatcherAssert.assertThat(actual.getCommand(), Matchers.equalTo("/registry"));
-        MatcherAssert.assertThat(
-            actual.getDescription(),
-            Matchers.equalTo("test registry description")
-        );
-    }
+  @Test
+  void createsBotCommand() {
+    final BotCommand actual = this.messageGenerator.asBotCommand();
+    MatcherAssert.assertThat(actual.getCommand(), Matchers.equalTo("/registry"));
+    MatcherAssert.assertThat(
+      actual.getDescription(),
+      Matchers.equalTo("test registry description")
+    );
+  }
 }


### PR DESCRIPTION
closes #53 
closes #54 

@l3r8yJ please take a look

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates package names and imports. 

### Detailed summary
- Renamed `io.blamer.bot.reponse` package to `io.blamer.bot.response`.
- Updated imports to reflect the package name changes.
- Updated method comments in `Conversation.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->